### PR TITLE
move total pages in the store

### DIFF
--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -35,7 +35,7 @@
                     <th>Actions</th>
                 </tr>
                 <UserOneRow
-                    v-for="user in filteredUsers"
+                    v-for="user in filteredUsers.slice($store.getters.beginPortion, $store.getters.endPortion)"
                     :key="user.id"
                     :user="user"
                 ></UserOneRow>
@@ -66,7 +66,6 @@ export default {
             begin: this.$store.state.beginPortion,
             end: this.$store.state.endPortion,
             isCreating: false,
-            search: '',
             isFiltered: true
         }
     },
@@ -116,9 +115,15 @@ export default {
         * @returns {array} filteredUsers
         */
         filteredUsers() {
-            return this.$store.state.users.filter(user => {
-                return user.lastname.toLowerCase().indexOf(this.search.toLowerCase()) > -1
-             }).slice(this.$store.getters.beginPortion, this.$store.getters.endPortion)
+            return this.$store.getters.filteredUsers;
+        },
+        search: {
+            get() {
+                return this.$store.state.search;
+            },
+            set(value) {
+                this.$store.commit('setSearch', value)
+            }
         },
         /**
         * TotalItems is equal to all users from the DB obtained by the getAllUsers method
@@ -132,7 +137,7 @@ export default {
         * @returns {number} totalPages
         */
         totalPages () {
-            return Math.ceil(this.totalItems.length / this.numberPerPage)
+            return this.$store.getters.totalPages;
         },
         /**
         * Dynamically linked to the current page of the store

--- a/store/index.js
+++ b/store/index.js
@@ -8,7 +8,8 @@ const createStore = () => {
             houses: [],
             selectedTab: 1,
             currentPage: 1,
-            numberPerPage: 15
+            numberPerPage: 15,
+            search: "",
         },
 
         getters: {
@@ -21,6 +22,21 @@ const createStore = () => {
             },
             endPortion(state) {
                 return (state.currentPage * state.numberPerPage) -1
+            },
+            filteredUsers(state, getters) {
+            return state.users
+                .filter(user => {
+                return (
+                    user.lastname
+                    .toLowerCase()
+                    .indexOf(state.search.toLowerCase()) > -1
+                );
+                });
+            },
+            totalPages(state, getters) {
+                return Math.ceil(
+                getters.filteredUsers.length / state.numberPerPage
+                );
             }
         },
 
@@ -36,7 +52,7 @@ const createStore = () => {
             // get current page
             setCurrentPage (state, page) {
                 state.currentPage = page
-            }, 
+            },
             // get all users from users/index.vue
             setUsers (state, users) {
                 state.users = users
@@ -65,8 +81,11 @@ const createStore = () => {
                     return house.id !== id
                 })
             },
+            setSearch(state, value) {
+                state.search = value;
+            }
         }
-    })
+    });
 }
 
 export default createStore


### PR DESCRIPTION
D'après moi, la solution est de bouger toute ta logique de pagination dans le store.

Tu as déjà tous les éléments requis pour faire ton calcul de pagination dans le store sauf la liste des éléments à afficher.

J'ai donc bougé `filteredUsers` dans ton store pour avoir la liste filtré disponible.
Ensuite j'ai bougé le calcul du total de page dans ton store pour le référencé directement.

N'hésite pas à faire des commentaires sur les lignes que tu ne comprends pas pour que j'éclaircisse, si tu préfères, on peut se voir rapidement que je t'explique en perso :)